### PR TITLE
change Price and Amount to long

### DIFF
--- a/WavesCS/OrderBook.cs
+++ b/WavesCS/OrderBook.cs
@@ -39,14 +39,14 @@ namespace WavesCS
 
         public class Ask
         {
-            public int Price { get; set; }
-            public int Amount { get; set; }
+            public long Price { get; set; }
+            public long Amount { get; set; }
         }
 
         public class Bid
         {
-            public int Price { get; set; }
-            public int Amount { get; set; }
+            public long Price { get; set; }
+            public long Amount { get; set; }
         }
 
         public class JsonOrderBook


### PR DESCRIPTION
Getting the Order Book for mrt (4uK8i4ThRGbehENwa6MxyLtxAjAo1Rj9fduborGExarC) or wbtc (8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS) failed because the Price and Amount can be very big.

Changing them to long fixed the issue.