### PR TITLE
Update SecurityProtocol on Http.cs

### DIFF
--- a/WavesCS/Http.cs
+++ b/WavesCS/Http.cs
@@ -56,7 +56,7 @@ namespace WavesCS
 
         public static string GetJson(string url, NameValueCollection headers = null)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
             Trace($"Getting: {url}");
             var client = new WebClient { Encoding = Encoding.UTF8 };
             if (headers != null)


### PR DESCRIPTION
SecurityProtocolType.Ssl3 Is not supported and is obsolete in .net core 
this update will fix the "NotSupportedException: The requested security protocol is not supported." problem at .net core usage.